### PR TITLE
General Updates and Amendments

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -1,6 +1,6 @@
 # Constitution of UQ Mechatronics and Robotics Society
 
-The constitution is enacted on this 9th day of March in the year 2023.
+The constitution is enacted on this 12th day of October in the year 2023.
 
 ---
 
@@ -84,7 +84,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 8.3 The election of T3 Officers and other members of the Executive Team shall take place in the following manner –
 
 * any two (2) members of The Club shall be at liberty to nominate any member to serve as an officer or other member of the Executive Team.
-* the nomination, which shall be in writing and signed by the member, the member's proposer (if different to the member) and seconder, shall be lodged with the secretary at least one (1) hour before the annual general meeting at which the election is to take place.
+* the nomination, which shall clearly identify the member, the member's proposer (if different to the member) and seconder, shall be lodged with the secretary at least one (1) hour before the general meeting at which the election is to take place.
 * at the commencement of such meeting, nominations may be taken from those present provided that they are seconded by someone else in attendance.
 * any informality or irregularity in the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the elections.
 * in the case of a secret ballot, the assembly will select a returning officer, who cannot be nominated for membership of the Executive Team and who shall be responsible for ensuring the orderly running of elections.
@@ -99,7 +99,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 9.3 Any member of the Executive Team may be removed from office at a general meeting of The Club where that member shall be given the opportunity to fully present the member's case.
 
-9.4 Should any member of the Executive Team other than the T3 Officers fail to attend at least three (3) consecutive meetings of the Executive Team, they may be removed from office at the next meeting of the Executive Team where that member shall be given the opportunity to fully present their case. In the event that they are removed under this clause, a notice must be sent to all current members advising of the decision.
+9.4 Should any member of the Executive Team, other than the T3 Officers, fail to attend at least three (3) consecutive meetings of the Executive Team, they may be removed from office at the next meeting of the Executive Team where that member shall be given the opportunity to fully present their case. In the event that they are removed under this clause, a notice must be sent to all current members advising of the decision.
 
 9.5 The question of removal shall be determined by a vote of 60% majority of the members present at such a meeting and must be endorsed by the Clubs and Societies committee.
 
@@ -138,7 +138,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 12.4 A special meeting of the Executive Team shall be convened by the Secretary on the requisition in writing signed by not less than one-third (1/3) of the members of the Executive Team, which requisition shall clearly state the reasons why such special meeting is being convened and the nature of the business to be transacted thereat.
 
-12.5 At every meeting of the Executive Team a simple majority of more than 50% of members elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team, shall constitute a quorum.
+12.5 At every meeting of the Executive Team a simple majority of more than 50% of members elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team or General Meeting, shall constitute a quorum.
 
 12.6 Subject as previously provided in this section, the Executive Team may meet together and regulate its proceedings as it thinks fit.
 
@@ -257,13 +257,13 @@ the meeting within fourteen (14) days of:
 
 ## 23 FUNDS AND ACCOUNTS
 
-23.1 The funds of The Club must be kept in the name of The Club in the University branch of the Commonwealth Bank. The Club shall operate one (1) account only. Exceptions to this can only occur with the specific approval of the Clubs and Societies committee.
+23.1 The funds of The Club must be kept in the name of The Club in the branch of the Commonwealth Bank delegated by The Union. The Club shall operate one (1) account only. Exceptions to this can only occur with the specific approval of the Clubs and Societies committee.
 
 23.2 Proper books and accounts shall be kept and maintained either in digital, written or printed form in the English language showing correctly the financial affairs of The Club and the particulars usually shown in books of a like nature.
 
 23.3 All monies shall be deposited in total as soon as practicable after receipt thereof.
 
-23.4 All amounts shall be paid by bank transfer signed by any two (2) of the president, secretary, treasurer, or other member authorised from time to time by the Executive Team and/or the Clubs and Societies Administration Officer.
+23.4 All amounts shall be paid by bank transfer signed by any two (2) of the T3 Officers, or other member authorised from time to time by the Executive Team and/or the Clubs and Societies Administration Officer.
 
 23.6 The Executive Team shall determine the amount of petty cash which shall be kept.
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -99,9 +99,11 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 9.3 Any member of the Executive Team may be removed from office at a general meeting of The Club where that member shall be given the opportunity to fully present the member's case.
 
-9.4 The question of removal shall be determined by a vote of 60% majority of the members present at such a general meeting and must be endorsed by the Clubs and Societies committee.
+9.4 Should any member of the Executive Team other than the T3 Officers fail to attend at least three (3) consecutive meetings of the Executive Team, they may be removed from office at the next meeting of the Executive Team where that member shall be given the opportunity to fully present their case. In the event that they are removed under this clause, a notice must be sent to all current members advising of the decision.
 
-9.5 There is no right of appeal against a member's removal from office under this section.
+9.5 The question of removal shall be determined by a vote of 60% majority of the members present at such a meeting and must be endorsed by the Clubs and Societies committee.
+
+9.6 There is no right of appeal against a member's removal from office under this section.
 
 ## 10 VACANCIES ON EXECUTIVE TEAM
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -87,7 +87,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 * any informality or irregularity in the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the elections.
 * in the case of a secret ballot, the assembly will select a returning officer, who cannot be nominated for membership of the Executive Team and who shall be responsible for ensuring the orderly running of elections.
 
-8.4 There shall at no time be less than three (3) members on the Executive Team (the T3), and no more than $\max{\left(10, \left\lfloor \sqrt{2n} \right\rfloor\right)}$ members on the Executive Team where $n$ represents the number of financial members of The Club as of the beginning of the most recent Annual General Meeting.
+8.4 There shall at no time be less than three (3) members on the Executive Team (the T3), and no more than $\max{\left(5, \left\lfloor \sqrt{\frac{69}{42}n} \right\rfloor\right)}$ members on the Executive Team where $n$ represents the number of financial members of The Club as of the beginning of the most recent Annual General Meeting.
 
 ## 9 RESIGNATION OR REMOVAL FROM OFFICE OF MEMBER OF EXECUTIVE TEAM
 
@@ -105,7 +105,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 10.1 The Executive Team shall have power at any time to appoint any member of The Club to fill any position on the Executive Team, other than the T3 Officers, until the next annual general meeting, provided that their appointment abides by the restrictions imposed in 8.4.
 
-10.2 Any such appointments shall be approved by all T3 Officers and determined by a vote of 70% majority of the members present at a quorate meeting of the Executive Team (per 12.5).
+10.2 Any such appointments shall be approved by all T3 Officers and determined by a vote of 75% majority of the members present at a quorate meeting of the Executive Team (per 12.5).
 
 10.3 The continuing members of the Executive Team may act notwithstanding any casual vacancy in the Executive Team, however if their number is reduced below the number fixed as is necessary for quorum of the Executive Team, the continuing member or members may act for the purpose of increasing the number of members of the Executive Team to that number required to achieve quorum or by summoning a general meeting of the association, but for no other purpose.
 
@@ -214,7 +214,7 @@ the meeting within fourteen (14) days of:
 
 ## 19 QUORUM AT GENERAL MEETING
 
-19.1 At any general meeting the number of members required to constitute a quorum shall be 15% of the number of financial members plus one (1).
+19.1 At any general meeting the number of members required to constitute a quorum shall be equal to $\left\lceil\min{\left(0.15n + 1, \frac{\pi}{e-1}\sqrt{n}\right)}\right\rceil$, where $n$ is the number of current financial members, $\pi\approx3.1415...$ is the circle constant, and $e\approx2.718...$ is Euler's number.
 
 ## 20 NOTICE OF GENERAL MEETING
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -89,7 +89,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 * any informality or irregularity in the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the elections.
 * in the case of a secret ballot, the assembly will select a returning officer, who cannot be nominated for membership of the Executive Team and who shall be responsible for ensuring the orderly running of elections.
 
-8.4 There shall at no time be less than three (3) members on the Executive Team (the T3 Officers), and no more than $\max{\left(5, \left\lfloor \sqrt{\frac{69}{42}n} \right\rfloor\right)}$ members on the Executive Team where $n$ represents the number of financial members of The Club as of the beginning of the latest Annual General Meeting (including the one in session, should this be the case).
+8.4 There shall at no time be less than three (3) members on the Executive Team (the T3 Officers), and no more than $\min{\left(Q, \left\lfloor \sqrt{\frac{69}{42}n} \right\rfloor\right)}$ members on the Executive Team where $Q$ and $n$ represent the quorum and number of financial members of The Club as of the beginning of the latest Annual General Meeting (including the one in session, should this be the case).
 
 ## 9 RESIGNATION OR REMOVAL FROM OFFICE OF MEMBER OF EXECUTIVE TEAM
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -39,13 +39,13 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 4.2 The Club shall have not less than thirty (30) financial members to remain a subsidised club.
 
-4.3 70% of The Club's membership must be students.
+4.3 At least 70% of The Club's membership must be students.
 
 4.4 The Club shall not adopt aims or objectives, which would bring it under the jurisdiction of the University of Queensland Sports Association (UQ Sport).
 
 ## 5 MEMBERSHIP FEES
 
-5.1 The membership fees shall be such sum, as the members shall from time to time at any general meeting so determine, but shall not be less than two (2) dollars per member per annum.
+5.1 The membership fees shall be such sum, as the Executive Team shall from time to time at any meeting of the Executive Team so determine, but shall not be less than two (2) dollars per member per annum.
 
 5.2 The membership fees shall be payable upon joining The Club.
 
@@ -132,7 +132,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 12.4 A special meeting of the Executive Team shall be convened by the Secretary on the requisition in writing signed by not less than one-third (1/3) of the members of the Executive Team, which requisition shall clearly state the reasons why such special meeting is being convened and the nature of the business to be transacted thereat.
 
-12.5 At every meeting of the Executive Team a simple majority of 50% of members plus one (1) elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team, shall constitute a quorum.
+12.5 At every meeting of the Executive Team a simple majority of over 50% of members elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team, shall constitute a quorum.
 
 12.6 Subject as previously provided in this section, the Executive Team may meet together and regulate its proceedings as it thinks fit.
 
@@ -248,7 +248,7 @@ the meeting within fourteen (14) days of:
 
 22.5 At any meeting at which a special resolution is submitted, a declaration by the chairperson that the resolution has been carried is conclusive proof of the fact unless a poll is demanded.
 
-22.6 In this section "entitled member" means a member of The Club who is entitled under the rules of the association to vote.
+22.6 In this section "entitled member" means a member of The Club who is entitled under the rules of The Club to vote.
 
 ## 23 FUNDS AND ACCOUNTS
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -15,9 +15,11 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 ## 2 NAME
 
-2.1 The Club shall be called the "UQ Mechatronics and Robotics Society", otherwise abbreviated to "UQ MARS".
+2.1 The Club shall be called the "UQ Mechatronics and Robotics Society Inc.", otherwise abbreviated to "UQ MARS".
 
-2.2 The Club shall be an associated body of the The Union in the category of Faculty/Departmental.
+2.2 The Club is an incorporated association, recognised by the Australian Office of Fair Trading under the Associations Incorporation Act 1981.
+
+2.3 The Club shall be an associated body of the The Union in the category of Faculty/Departmental.
 
 ## 3 AIMS & OBJECTIVES
 
@@ -87,7 +89,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 * any informality or irregularity in the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the elections.
 * in the case of a secret ballot, the assembly will select a returning officer, who cannot be nominated for membership of the Executive Team and who shall be responsible for ensuring the orderly running of elections.
 
-8.4 There shall at no time be less than three (3) members on the Executive Team (the T3), and no more than $\max{\left(5, \left\lfloor \sqrt{\frac{69}{42}n} \right\rfloor\right)}$ members on the Executive Team where $n$ represents the number of financial members of The Club as of the beginning of the most recent Annual General Meeting.
+8.4 There shall at no time be less than three (3) members on the Executive Team (the T3 Officers), and no more than $\max{\left(5, \left\lfloor \sqrt{\frac{69}{42}n} \right\rfloor\right)}$ members on the Executive Team where $n$ represents the number of financial members of The Club as of the beginning of the latest Annual General Meeting (including the one in session, should this be the case).
 
 ## 9 RESIGNATION OR REMOVAL FROM OFFICE OF MEMBER OF EXECUTIVE TEAM
 
@@ -105,9 +107,11 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 10.1 The Executive Team shall have power at any time to appoint any member of The Club to fill any position on the Executive Team, other than the T3 Officers, until the next annual general meeting, provided that their appointment abides by the restrictions imposed in 8.4.
 
-10.2 Any such appointments shall be approved by all T3 Officers and determined by a vote of 75% majority of the members present at a quorate meeting of the Executive Team (per 12.5).
+10.2 Should there be a vacancy in the position of one of the T3 Officers, a member of the Executive Team can be appointed to fill the position until the next general meeting. In the event that the Executive Team contains no members who are not T3 Officers, and only then, can the club appoint any member of The Club to fill this position until the next general meeting.
 
-10.3 The continuing members of the Executive Team may act notwithstanding any casual vacancy in the Executive Team, however if their number is reduced below the number fixed as is necessary for quorum of the Executive Team, the continuing member or members may act for the purpose of increasing the number of members of the Executive Team to that number required to achieve quorum or by summoning a general meeting of the association, but for no other purpose.
+10.3 Any such appointments shall be approved by all T3 Officers and determined by a vote of 75% majority of the members present at a quorate meeting of the Executive Team (per 12.5).
+
+10.4 The continuing members of the Executive Team may act notwithstanding any casual vacancy in the Executive Team, however if their number is reduced below the number fixed as is necessary for quorum of the Executive Team, the continuing member or members may act for the purpose of increasing the number of members of the Executive Team to that number required to achieve quorum or by summoning a general meeting of the association, but for no other purpose.
 
 ## 11 FUNCTIONS OF THE EXECUTIVE TEAM
 
@@ -132,7 +136,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 12.4 A special meeting of the Executive Team shall be convened by the Secretary on the requisition in writing signed by not less than one-third (1/3) of the members of the Executive Team, which requisition shall clearly state the reasons why such special meeting is being convened and the nature of the business to be transacted thereat.
 
-12.5 At every meeting of the Executive Team a simple majority of over 50% of members elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team, shall constitute a quorum.
+12.5 At every meeting of the Executive Team a simple majority of more than 50% of members elected and/or appointed to the Executive Team as at the close of the last meeting of the Executive Team, shall constitute a quorum.
 
 12.6 Subject as previously provided in this section, the Executive Team may meet together and regulate its proceedings as it thinks fit.
 
@@ -144,7 +148,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 12.10 Such notice shall clearly state the nature of the business to be discussed thereat.
 
-12.11 The president shall preside as chairperson at every meeting of the Executive Team, or if there is no president, or if at any meeting the president is not present within ten (10) minutes after the time appointed for holding the meeting, another T3 Officer shall be chosen to be chairperson or if none of the T3 are present at the meeting then the meeting shall lapse.
+12.11 The president shall preside as chairperson at every meeting of the Executive Team, or if there is no president, or if at any meeting the president is not present within ten (10) minutes after the time appointed for holding the meeting, another T3 Officer shall be chosen to be chairperson or if none of the T3 Officers are present at the meeting then the meeting shall lapse.
 
 12.12 If within fifteen (15) minutes from the time appointed for the commencement of a Executive Team meeting a quorum is not present, the meeting, if convened upon the requisition of members of the Executive Team, shall lapse.
 
@@ -198,8 +202,7 @@ The constitution is enacted on this 9th day of March in the year 2023.
 
 17.2 The minutes of the annual general meeting shall be submitted to the The Union's Clubs and Societies Administration Officer within seven (7) days of the annual general meeting
 
-17.3 Where there is a tied vote, the issue will be deemed to have been resolved in the
-negative.
+17.3 Where there is a tied vote, the issue will be deemed to have been resolved in the negative.
 
 ## 18 SPECIAL GENERAL MEETING
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -257,7 +257,7 @@ the meeting within fourteen (14) days of:
 
 ## 23 FUNDS AND ACCOUNTS
 
-23.1 The funds of The Club must be kept in the name of The Club in the branch of the Commonwealth Bank delegated by The Union. The Club shall operate one (1) account only. Exceptions to this can only occur with the specific approval of the Clubs and Societies committee.
+23.1 The funds of The Club must be kept in the name of The Club in the banking branch delegated by The Union. The Club shall operate one (1) account only. Exceptions to this can only occur with the specific approval of the Clubs and Societies committee.
 
 23.2 Proper books and accounts shall be kept and maintained either in digital, written or printed form in the English language showing correctly the financial affairs of The Club and the particulars usually shown in books of a like nature.
 


### PR DESCRIPTION
This update is mostly intended to address a couple of oversights in terminology that were skipped over in my last big update at the SGM. These are largely applying terms from section 2 to the rest of the document. Outside of these, the notable changes are:

* Update the exec cap. We've observed this year how hard it can be to handle larger teams, so this has been updated to enforce a slightly lower cap (with the added benefit of the funny number).
* Update general meeting quorum. As the club continues to scale and grow, the linear growth of the quorum means that the general meetings would be required to get rather large, which would be a logistical pain with no clear benefit. The newer model constrains the quorum to the current linear model for low membership numbers, but tapers it off at around 150 members to that of a square root relation.
* Added a clause for the removal of inactive executives. In the case of exec members who don't contribute to the club, I don't think it is fair on the active members of the executive team to need to take on the extra burden of arranging an SGM to remove them. The extra clause would mean that anyone who can't even show up to three consecutive exec meetings can be voted out by the rest of the exec team at an exec meeting (and notify all members for transparency).