### PR TITLE
Introduce Life Membership

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -290,3 +290,17 @@ the meeting within fourteen (14) days of:
 26.1 The Executive Team shall provide for the safe custody of books, documents, instruments of title and securities of The Club.
 
 26.2 The financial year of The Club shall close on 31 August in each year.
+
+## 27 LIFE MEMBERSHIP
+
+27.1 The honourary title of life member may be presented to former members of the Executive Team via special resolution at a general meeting of The Club. This title is intended to honour those that have made significant contributions to The Club and have since remained close to it.
+
+27.2 Such resolution is bound by the same rules as are outlined for special resolutions in section 22 regarding the alteration of rules.
+
+27.3 In order to be voted in as a life member, the individual must meet all of the following:
+
+* Must have previously been a member of the Executive Team
+* Must not have been a member of the Executive Team within the past two (2) years
+
+27.4 Life members shall for all purposes be considered members of The Club, with the exception of the classification of "financial members". Financial membership does not apply to life members.
+

--- a/Constitution.md
+++ b/Constitution.md
@@ -300,7 +300,7 @@ the meeting within fourteen (14) days of:
 27.3 In order to be voted in as a Life Member, the individual must meet all of the following:
 
 * Must have previously been a member of the Executive Team
-* Must not have been a member of the Executive Team within the past two (2) years
+* Must not have been a member of the Executive Team within the past two (2) calendar years
 
 27.4 Life Members shall for all purposes be considered members of The Club, with the exception of the classification of "financial members". Financial membership does not apply to Life Members.
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -293,14 +293,14 @@ the meeting within fourteen (14) days of:
 
 ## 27 LIFE MEMBERSHIP
 
-27.1 The honourary title of life member may be presented to former members of the Executive Team via special resolution at a general meeting of The Club. This title is intended to honour those that have made significant contributions to The Club and have since remained close to it.
+27.1 The honourary title of Life Member may be presented to former members of the Executive Team via special resolution at a general meeting of The Club. This title is intended to honour those that have made significant contributions to The Club and have since remained close to it.
 
 27.2 Such resolution is bound by the same rules as are outlined for special resolutions in section 22 regarding the alteration of rules.
 
-27.3 In order to be voted in as a life member, the individual must meet all of the following:
+27.3 In order to be voted in as a Life Member, the individual must meet all of the following:
 
 * Must have previously been a member of the Executive Team
 * Must not have been a member of the Executive Team within the past two (2) years
 
-27.4 Life members shall for all purposes be considered members of The Club, with the exception of the classification of "financial members". Financial membership does not apply to life members.
+27.4 Life Members shall for all purposes be considered members of The Club, with the exception of the classification of "financial members". Financial membership does not apply to Life Members.
 

--- a/Life-Members.md
+++ b/Life-Members.md
@@ -1,0 +1,8 @@
+# Life Members of UQ MARS
+
+Per Section 27 of the constitution, life membership is an honourary title that may be awarded to former members of the Executive Team of UQ MARS in recognition of their contributions to the club and their continued support. This document is a list of the current Life Members.
+
+| Full Name | Time of Award |
+| ----- | ----- |
+|   |   |
+


### PR DESCRIPTION
One of the goals of our exec team this year has been to rediscover the club's history and try to re-engage with those who have come before us. I believe that this is important for the club, as it helps us to learn from the past as well as keep a strong network with alumni who might be interested in supporting members. A potential solution to help address this that I have seen been successful in other clubs is the idea of life members. The goal of this would be to honour those that have been influential in MARS' history and since demonstrated a continued commitment and support of the club.