### PR TITLE
Introduce Official UQ MARS Code of Conduct

### DIFF
--- a/Code-Of-Conduct.md
+++ b/Code-Of-Conduct.md
@@ -2,7 +2,7 @@
 
 Observe that this document will observe the same definitions as outlined in Section 1 of the Constitution of the UQ Mechatronics and Robotics Society.
 
-This document is to lay out the specific details of the Code of Conduct that members of the Executive Team, other members of The Club, and any other individuals who may engage with The Club are expected to follow. Failure to comply with this Code of Conduct is grounds for disciplinary actions, as determined fair by the Executive Team.
+This document is to lay out the specific details of the Code of Conduct that members of the Executive Team, other members of The Association, and any other individuals who may engage with The Association are expected to follow. Failure to comply with this Code of Conduct is grounds for disciplinary actions, as determined fair by the Executive Team.
 
 This version of the Code of Conduct is enacted and current as of this 10th day of October, 2024.
 
@@ -10,42 +10,42 @@ This version of the Code of Conduct is enacted and current as of this 10th day o
 
 ## The Union Code of Conduct
 
-As an associated body of The Union, The Club observes and adheres to the common Code of Conduct as observed by The Union. This document builds upon, and is intended to extend, the Code of Conduct observed by The Union as found through [their website](https://uqu.com.au/c-and-s-resources/). The contents of the Code of Conduct of The Union shall be considered a part of this Code of Conduct of The Club.
+As an associated body of The Union, The Association observes and adheres to the common Code of Conduct as observed by The Union. This document builds upon, and is intended to extend, the Code of Conduct observed by The Union as found through [their website](https://uqu.com.au/c-and-s-resources/). The contents of the Code of Conduct of The Union shall be considered a part of this Code of Conduct of The Association.
 
 ## The Spirit of the Rules
 
 Where ambiguities may exist in this Code of Conduct and specific behaviours are not explicitly covered, or specific examples that match a given circumstance are not directly highlighted here, discretion may be made by the Executive Team - or other bodies, such as The Union - to whether such circumstances align with the 'Spirit of the Rules'.
 
-## Behavioural Expectations of The Club
+## Behavioural Expectations of The Association
 
-The following lays out the behavioural requirements when using The Services of The Club, where 'The Services' refers to the events, initiatives, and platforms made available by The Club, which can include:
+The following lays out the behavioural requirements when using The Services of The Association, where 'The Services' refers to the events, initiatives, and platforms made available by The Association, which can include:
 
 - Online Platforms (such as Discord, YouTube, Facebook, Instagram, LinkedIn, etc)
-- Physical Engagements (such as in-person events and meet-ups arranged, hosted, or cohosted by The Club)
-- Interpersonal Interactions (such as direct messages or private discussions that stem from The Club)
+- Physical Engagements (such as in-person events and meet-ups arranged, hosted, or cohosted by The Association)
+- Interpersonal Interactions (such as direct messages or private discussions that stem from The Association)
 
 While the following breaks down expectations into categories of The Services, the categorisation is not a limitation on which services to which the expectations are applied.
 
 ### Online Platforms
 
-When using and interacting with digital, online platforms operated and/or provided by The Club, users must adhere to the following:
+When using and interacting with digital, online platforms operated and/or provided by The Association, users must adhere to the following:
 
 - Treat everyone with respect. Absolutely no harassment, witch hunting, sexism, racism, or hate speech will be tolerated.
 - No 'Not Safe For Work' (NSFW) or obscene content is to be distributed via these platforms.
 - No spam or unsolicited promotion is to be shared. Where uncertain, seek advice from the Executive Team.
-- Hacking or the attempt of hacking another member of The Club, or any other associated bodies of The Union, through these platforms or elsewhere is forbidden.
-- Solicition of academic misconduct through these platforms or elsewhere related to The Club is forbidden.
+- Hacking or the attempt of hacking another member of The Association, or any other associated bodies of The Union, through these platforms or elsewhere is forbidden.
+- Solicition of academic misconduct through these platforms or elsewhere related to The Association is forbidden.
 
 ### Physical Engagements 
 
-Where an individual is engaging with Physical Engagements of The Club, they must not partake in malicious antisocial behaviours, which coudl include the following:
+Where an individual is engaging with Physical Engagements of The Association, they must not partake in malicious antisocial behaviours, which coudl include the following:
 
 - Physical intimidation to cause stress or coerce unwilling behaviours.
 - Non-consensual sexual or similar inappropriate acts or discussions.
 
 ### Interpersonal Interactions
 
-As The Club seeks to connect likeminded individuals, there is an inherent trust in The Club to provide a safe and welcoming environment. Where individuals meet through The Services of The Club, there shall be no behaviours taken that knowingly or intentionally cause others to feel unsafe or unwelcome. These such forbidden behaviours may include:
+As The Association seeks to connect likeminded individuals, there is an inherent trust in The Association to provide a safe and welcoming environment. Where individuals meet through The Services of The Association, there shall be no behaviours taken that knowingly or intentionally cause others to feel unsafe or unwelcome. These such forbidden behaviours may include:
 
 - Harassment
 - Stalking
@@ -54,11 +54,11 @@ As The Club seeks to connect likeminded individuals, there is an inherent trust 
 
 ## Disciplinary Actions 
 
-Where the above Code of Conduct is broken or ignored with relation to The Services of The Club, perpetrating individuals may be subject to disciplinary action. Depending on the severity of the incident, this could include:
+Where the above Code of Conduct is broken or ignored with relation to The Services of The Association, perpetrating individuals may be subject to disciplinary action. Depending on the severity of the incident, this could include:
 
 - Official warning
-- Removal from an event hosted by The Club
-- Removal from any organisational bodies that exist within The Club
-- A time-limited ban from all activities of The Club
-- A lifetime ban from all activities of The Club
+- Removal from an event hosted by The Association
+- Removal from any organisational bodies that exist within The Association
+- A time-limited ban from all activities of The Association
+- A lifetime ban from all activities of The Association
 - Reporting to higher bodies, such as The Union, The University, or law enforcement

--- a/Code-Of-Conduct.md
+++ b/Code-Of-Conduct.md
@@ -10,11 +10,11 @@ This version of the Code of Conduct is enacted and current as of this 10th day o
 
 ## The Union Code of Conduct
 
-As an associated body of The Union, The Club observes and adheres to the common Code of Conduct as observed by The Union. This document builds upon, and is intended to extend, the Code of Conduct observed by The Union as found through [their website](https://uqu.com.au/c-and-s-resources/).
+As an associated body of The Union, The Club observes and adheres to the common Code of Conduct as observed by The Union. This document builds upon, and is intended to extend, the Code of Conduct observed by The Union as found through [their website](https://uqu.com.au/c-and-s-resources/). The contents of the Code of Conduct of The Union shall be considered a part of this Code of Conduct of The Club.
 
 ## The Spirit of the Rules
 
-Where ambiguities may exist in this Code of Conduct and specific behaviours are not explicitly covered, or specific examples that match a given circumstance are not directly highlighted here, discretion may be made by the Executive Team - or other bodies such as The Union - to whether such circumstances align with the 'Spirit of the Rules'.
+Where ambiguities may exist in this Code of Conduct and specific behaviours are not explicitly covered, or specific examples that match a given circumstance are not directly highlighted here, discretion may be made by the Executive Team - or other bodies, such as The Union - to whether such circumstances align with the 'Spirit of the Rules'.
 
 ## Behavioural Expectations of The Club
 
@@ -36,18 +36,29 @@ When using and interacting with digital, online platforms operated and/or provid
 - Hacking or the attempt of hacking another member of The Club, or any other associated bodies of The Union, through these platforms or elsewhere is forbidden.
 - Solicition of academic misconduct through these platforms or elsewhere related to The Club is forbidden.
 
-## Physical Engagements 
+### Physical Engagements 
 
-Where an individual is engaging with Physical Engagements of The Club, they must not partake in the following behaviours:
+Where an individual is engaging with Physical Engagements of The Club, they must not partake in malicious antisocial behaviours, which coudl include the following:
 
 - Physical intimidation to cause stress or coerce unwilling behaviours.
-- Non-consensual, inappropriate or sexual acts or discussions.
+- Non-consensual sexual or similar inappropriate acts or discussions.
 
-## Interpersonal Interactions
+### Interpersonal Interactions
 
 As The Club seeks to connect likeminded individuals, there is an inherent trust in The Club to provide a safe and welcoming environment. Where individuals meet through The Services of The Club, there shall be no behaviours taken that knowingly or intentionally cause others to feel unsafe or unwelcome. These such forbidden behaviours may include:
 
 - Harassment
 - Stalking
 - Intimidation or blackmail
-- Continued contact despite requests to stop
+- Continued, undesired contact
+
+## Disciplinary Actions 
+
+Where the above Code of Conduct is broken or ignored with relation to The Services of The Club, perpetrating individuals may be subject to disciplinary action. Depending on the severity of the incident, this could include:
+
+- Official warning
+- Removal from an event hosted by The Club
+- Removal from any organisational bodies that exist within The Club
+- A time-limited ban from all activities of The Club
+- A lifetime ban from all activities of The Club
+- Reporting to higher bodies, such as The Union, The University, or law enforcement

--- a/Code-Of-Conduct.md
+++ b/Code-Of-Conduct.md
@@ -1,0 +1,53 @@
+# Code of Conduct of the UQ Mechatronics and Robotics Society Inc
+
+Observe that this document will observe the same definitions as outlined in Section 1 of the Constitution of the UQ Mechatronics and Robotics Society.
+
+This document is to lay out the specific details of the Code of Conduct that members of the Executive Team, other members of The Club, and any other individuals who may engage with The Club are expected to follow. Failure to comply with this Code of Conduct is grounds for disciplinary actions, as determined fair by the Executive Team.
+
+This version of the Code of Conduct is enacted and current as of this 10th day of October, 2024.
+
+-----
+
+## The Union Code of Conduct
+
+As an associated body of The Union, The Club observes and adheres to the common Code of Conduct as observed by The Union. This document builds upon, and is intended to extend, the Code of Conduct observed by The Union as found through [their website](https://uqu.com.au/c-and-s-resources/).
+
+## The Spirit of the Rules
+
+Where ambiguities may exist in this Code of Conduct and specific behaviours are not explicitly covered, or specific examples that match a given circumstance are not directly highlighted here, discretion may be made by the Executive Team - or other bodies such as The Union - to whether such circumstances align with the 'Spirit of the Rules'.
+
+## Behavioural Expectations of The Club
+
+The following lays out the behavioural requirements when using The Services of The Club, where 'The Services' refers to the events, initiatives, and platforms made available by The Club, which can include:
+
+- Online Platforms (such as Discord, YouTube, Facebook, Instagram, LinkedIn, etc)
+- Physical Engagements (such as in-person events and meet-ups arranged, hosted, or cohosted by The Club)
+- Interpersonal Interactions (such as direct messages or private discussions that stem from The Club)
+
+While the following breaks down expectations into categories of The Services, the categorisation is not a limitation on which services to which the expectations are applied.
+
+### Online Platforms
+
+When using and interacting with digital, online platforms operated and/or provided by The Club, users must adhere to the following:
+
+- Treat everyone with respect. Absolutely no harassment, witch hunting, sexism, racism, or hate speech will be tolerated.
+- No 'Not Safe For Work' (NSFW) or obscene content is to be distributed via these platforms.
+- No spam or unsolicited promotion is to be shared. Where uncertain, seek advice from the Executive Team.
+- Hacking or the attempt of hacking another member of The Club, or any other associated bodies of The Union, through these platforms or elsewhere is forbidden.
+- Solicition of academic misconduct through these platforms or elsewhere related to The Club is forbidden.
+
+## Physical Engagements 
+
+Where an individual is engaging with Physical Engagements of The Club, they must not partake in the following behaviours:
+
+- Physical intimidation to cause stress or coerce unwilling behaviours.
+- Non-consensual, inappropriate or sexual acts or discussions.
+
+## Interpersonal Interactions
+
+As The Club seeks to connect likeminded individuals, there is an inherent trust in The Club to provide a safe and welcoming environment. Where individuals meet through The Services of The Club, there shall be no behaviours taken that knowingly or intentionally cause others to feel unsafe or unwelcome. These such forbidden behaviours may include:
+
+- Harassment
+- Stalking
+- Intimidation or blackmail
+- Continued contact despite requests to stop


### PR DESCRIPTION
It was observed this year that MARS do not officially have, or display an association Code of Conduct. Whilst we do follow that of the UQ Union of which it prescribes to all associated clubs and societies, I thought it would be worthwhile laying out our own, and expanding upon that which we automatically follow from the union.