### PR TITLE
Introduce UQ MARS Regulations

### DIFF
--- a/Regulations.md
+++ b/Regulations.md
@@ -139,7 +139,7 @@ Within this document, the following definitions will be used:
 
 5.12 An exclusion to 5.6, 5.7, and 5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
 
-5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election.
+5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election. Their term shall end when their successor commences the following year in line with these Regulations.
 
 ## 6 MARS Central Management Team
 

--- a/Regulations.md
+++ b/Regulations.md
@@ -2,7 +2,7 @@
 
 This revision of the regulations is enacted and valid as of this 10th day of October, 2024.
 
-These regulations are supplementary to The Constitution, with the purpose to standardise the interpretation of The Constitution. Any Regulations created should have little to no impact upon Club Members who do not belong to the Management Committee outside that which The Constitution already impacts.
+These regulations are supplementary to The Constitution, with the purpose to standardise the interpretation of The Constitution. Any Regulations created should have little to no impact upon Association Members who do not belong to the Management Committee outside that which The Constitution already impacts.
 
 In the event that there are any contradictions between these Regulations and The Constitution, then The Constitution shall take precedence. In such a case, these Regulations should be revised.
 
@@ -12,29 +12,29 @@ In the event that there are any contradictions between these Regulations and The
 
 Within this document, the following definitions will be used:
 
-* "The Club" shall refer to the UQ Mechatronics and Robotics Society Inc.
+* "The Association" shall refer to the UQ Mechatronics and Robotics Society Inc.
 * "The University" shall refer to the University of Queensland.
 * "The Union" shall refer to the University of Queensland Union.
 * "The Constitution" shall refer to the governing constitution of the UQ Mechatronics and Robotics Society Inc.
-* "Club Member" shall refer to an individual belonging to the community of The Club who is eligible to vote on matters at General Meetings.
-* "Financial Member" shall refer to a Club Member who is also required to pay a membership fee.
+* "Association Member" shall refer to an individual belonging to the community of The Association who is eligible to vote on matters at General Meetings.
+* "Financial Member" shall refer to a Association Member who is also required to pay a membership fee.
 * "Calendar Year" shall refer to the period of time that runs from January 1 through to December 31.
 
 ## Sections found in the Regulations
 
-- [Section 1: Bodies of The Club](#section-1-bodies-of-the-club)
+- [Section 1: Bodies of The Association](#section-1-bodies-of-the-association)
 - [Section 2: Amendments to Regulations](#section-2-amendments-to-regulations)
 - [Section 3: General Meetings and Executive Elections](#section-3-general-meetings-and-executive-elections)
 
 ---
 
-# Section 1: Bodies of The Club
+# Section 1: Bodies of The Association
 
-## 1 Management Committee of The Club
+## 1 Management Committee of The Association
 
-1.1 The Management Committee of The Club shall be the body responsible for the management of The Club.
+1.1 The Management Committee of The Association shall be the body responsible for the management of The Association.
 
-1.2 The Management Committee is to be comprised of the union of members from the following bodies of The Club:
+1.2 The Management Committee is to be comprised of the union of members from the following bodies of The Association:
 
 - T3 Officers (as described by The Constitution)
 - T5 Officers
@@ -44,13 +44,13 @@ Within this document, the following definitions will be used:
 - Mechatronics Society Management Team
 - Robotics Club Management Team
 
-1.3 As presented by The Constitution, each body exists as a subcommittee of Club Members.
+1.3 As presented by The Constitution, each body exists as a subcommittee of Association Members.
 
 1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.2.
 
 ## 2 T3 Officers
 
-2.1 The T3 Officers shall be the chief administrative body of The Club, responsible for management of The Management Committee, The Club's finances, and for any external commitments of The Club such as to The University or to The Union.
+2.1 The T3 Officers shall be the chief administrative body of The Association, responsible for management of The Management Committee, The Association's finances, and for any external commitments of The Association such as to The University or to The Union.
 
 2.2 Membership of the T3 Officers shall be made up of:
 
@@ -62,7 +62,7 @@ Within this document, the following definitions will be used:
 
 ## 3 T5 Officers
 
-3.1 The T5 Officers shall be an extension of the T3 Officers, responsible for the oversight of events and initiatives of The Club and coordination of the various offerings and initiatives of The Club.
+3.1 The T5 Officers shall be an extension of the T3 Officers, responsible for the oversight of events and initiatives of The Association and coordination of the various offerings and initiatives of The Association.
 
 3.2 Membership of the T5 Officers shall be made up of:
 
@@ -78,7 +78,7 @@ Within this document, the following definitions will be used:
 
 ## 4 Executive Team
 
-4.1 The Executive Team is the overall leadership body of The Club, directly producing and operating the various offerings and initiatives of The Club.
+4.1 The Executive Team is the overall leadership body of The Association, directly producing and operating the various offerings and initiatives of The Association.
 
 4.2 Membership of the Executive Team shall be made up of:
 
@@ -96,7 +96,7 @@ Within this document, the following definitions will be used:
 - Outreach Lead
 - Projects Lead
 
-4.3 The Executive Team are elected by Club Members at General Meetings of The Club, as outlined by The Constitution.
+4.3 The Executive Team are elected by Association Members at General Meetings of The Association, as outlined by The Constitution.
 
 4.4 The Executive Team shall meet once per calendar month as called by the Secretary.
 
@@ -104,14 +104,14 @@ Within this document, the following definitions will be used:
 
 ## 5 Martian Council
 
-5.1 The Martian Council is an advisory body, set up to ensure that the interests of Club Members are heard and enacted.
+5.1 The Martian Council is an advisory body, set up to ensure that the interests of Association Members are heard and enacted.
 
 5.2 Membership of the Martian Council shall be made up of:
 
 - President
 - Secretary
 - Treasurer
-- One (1) Club Member representing each of the following demographics:
+- One (1) Association Member representing each of the following demographics:
     - Electrical Engineering Students
     - Mechanical Engineering Students
     - Software Engineering Students
@@ -125,7 +125,7 @@ Within this document, the following definitions will be used:
 
 5.5 A limit of Two (2) terms shall be imposed upon representatives of the Martian Council.
 
-5.6 Nominations for the representative roles are to open within 48 hours of the close of the Annual General Meeting of The Club each year, and remain open until 11:59 pm on the 30th day of November that same year.
+5.6 Nominations for the representative roles are to open within 48 hours of the close of the Annual General Meeting of The Association each year, and remain open until 11:59 pm on the 30th day of November that same year.
 
 5.7 Election of the representatives shall be held during the December meeting of the Management Committee, with the voting system left to the discretion of the President, who shall manage the votes.
 
@@ -133,7 +133,7 @@ Within this document, the following definitions will be used:
 
 5.9 Representatives may resign from their post by written notice to the Secretary no less than fourteen (14) days in advance of their departure, at which time a casual vacancy be opened.
 
-5.10 In the event of a casual vacancy, nominations for the open role shall be released to Club Members for a period of seven (7) days, with the successor to be elected at the first meeting to be held by following the closure of nominations by any of the following bodies: the Management Committee, the T5 Officers, or the Executive Team.
+5.10 In the event of a casual vacancy, nominations for the open role shall be released to Association Members for a period of seven (7) days, with the successor to be elected at the first meeting to be held by following the closure of nominations by any of the following bodies: the Management Committee, the T5 Officers, or the Executive Team.
 
 5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
 
@@ -141,7 +141,7 @@ Within this document, the following definitions will be used:
 
 ## 6 MARS Central Management Team
 
-6.1 The MARS Central Management Team (hereon referred to as the "Central Team") are a body responsible for providing the core services needed to allow and enhance the other events, teams, and initiatives provided by The Club.
+6.1 The MARS Central Management Team (hereon referred to as the "Central Team") are a body responsible for providing the core services needed to allow and enhance the other events, teams, and initiatives provided by The Association.
 
 6.2 Membership of the Central Team shall be made up of:
 
@@ -159,8 +159,8 @@ Within this document, the following definitions will be used:
 
 7.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
 
-- engage Club Members enrolled in the study of mechatronic engineering or a related discipline amongst their peers, The University, and the wider industry
-- provide events and opportunities for Club Members to develop employable skills
+- engage Association Members enrolled in the study of mechatronic engineering or a related discipline amongst their peers, The University, and the wider industry
+- provide events and opportunities for Association Members to develop employable skills
 
 7.2 Membership of the Society Team shall be made up of:
 
@@ -177,8 +177,8 @@ Within this document, the following definitions will be used:
 
 8.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
 
-- provide Club Members with industry-ready technical experiences
-- provide opportunities for Club Members to compete at higher level robotics competitions
+- provide Association Members with industry-ready technical experiences
+- provide opportunities for Association Members to compete at higher level robotics competitions
 
 8.2 Membership of the Society Team shall be made up of:
 
@@ -198,7 +198,7 @@ Within this document, the following definitions will be used:
 
 9.2 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Martian Council for the Secretary to include as a motion for a quorate meeting of the Martian Council, which can be passed through unanimous vote.
 
-9.3 Amendments to The Regulations can be proposed by Club Members as a Special Resolution to be discussed at a General Meeting in line with The Constitution.
+9.3 Amendments to The Regulations can be proposed by Association Members as a Special Resolution to be discussed at a General Meeting in line with The Constitution.
 
 9.4 When Amendments are made, it is the duty of the Secretary to notify all current members of the Management Committee of the update.
 
@@ -208,7 +208,7 @@ Within this document, the following definitions will be used:
 
 ## 10 Elections of the Executive Team
 
-10.1 At the Annual General Meeting of The Club, the method by which the Executive Team is elected shall be that of a secret ballot.
+10.1 At the Annual General Meeting of The Association, the method by which the Executive Team is elected shall be that of a secret ballot.
 
 10.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
 
@@ -216,7 +216,7 @@ Within this document, the following definitions will be used:
 
 ## 11 Order of Elections
 
-11.1 At a General Meeting of The Club where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
+11.1 At a General Meeting of The Association where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
 
 1. T3 Officers
 2. T5 Officers
@@ -252,7 +252,7 @@ Within this document, the following definitions will be used:
 
 12.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
 
-12.2 The Returning Officer does not need to be a Club Member.
+12.2 The Returning Officer does not need to be a Association Member.
 
 12.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
 

--- a/Regulations.md
+++ b/Regulations.md
@@ -119,9 +119,9 @@ Within this document, the following definitions will be used:
     - First Year Students
     - Postgraduate Students
 
-5.3 The representative positions cannot be members of the Executive Team.
+5.3 Members of the Executive Team shall be ineligible to nominate for a representative role on the council, and representative members of the Martian Council shall only be eligible to nominate for a position on the Executive Team at an Annual General Meeting of The Association.
 
-5.4 The term of each representative shall be One (1) Calendar Year between elections.
+5.4 The term of each representative shall be One (1) Calendar Year.
 
 5.5 A limit of Two (2) terms shall be imposed upon representatives of the Martian Council.
 
@@ -137,7 +137,9 @@ Within this document, the following definitions will be used:
 
 5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
 
-<!-- Further consider first year, may need alternative arrangements -->
+5.12 An exclusion to 5.6, 5.7, and 5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
+
+5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election.
 
 ## 6 MARS Central Management Team
 

--- a/Regulations.md
+++ b/Regulations.md
@@ -1,0 +1,170 @@
+# Regulations of the UQ Mechatronics and Robotics Society
+
+This revision of the regulations is enacted and valid as of this 10th day of October, 2024.
+
+These regulations are supplementary to The Constitution. In the event that there are any contradictions between these Regulations and The Constitution, then The Constitution shall take precedence.
+
+---
+
+## Definitions
+
+Within this document, the following definitions will be used:
+
+* "The Club" shall refer to the UQ Mechatronics and Robotics Society Inc.
+* "The University" shall refer to the University of Queensland.
+* "The Union" shall refer to the University of Queensland Union.
+* "The Constitution" shall refer to the governing constitution of the UQ Mechatronics and Robotics Society Inc.
+* "Club Member" shall refer to an individual belonging to the community of The Club who is eligible to vote on matters at General Meetings.
+* "Financial Member" shall refer to a Club Member who is also required to pay a membership fee.
+* "Calendar Year" shall refer to the period of time that runs from January 1 through to December 31.
+
+## Sections found in the Regulations
+
+- [Section 1: Bodies of The Club](#section-1:-bodies-of-the-club)
+
+---
+
+# Section 1: Bodies of The Club
+
+## 1 Management Committee of The Club
+
+1.1 The Management Committee of The Club shall be the body responsible for the management of The Club.
+
+1.2 The Management Committee is to be comprised of the union of members from the following bodies of The Club:
+
+- T3 Officers (as described by The Constitution)
+- T5 Officers
+- Executive Team (as described by The Constitution)
+- Martian Council
+- Mechatronics Society Management Team
+- Robotics Club Management Team
+
+1.3 As presented by The Constitution, each body exists as a subcommittee of Club Members.
+
+1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.2.
+
+## 2 T3 Officers
+
+2.1 The T3 Officers shall be the chief administrative body of The Club, responsible for management of The Management Committee, The Club's finances, and for any external commitments of The Club such as to The University or to The Union.
+
+2.2 Membership of the T3 Officers shall be made up of:
+
+- President
+- Secretary
+- Treasurer
+
+2.3 The T3 Officers are a subset of the Executive Team, and thus follow the same election process.
+
+## 3 T5 Officers
+
+3.1 The T5 Officers shall be an extension of the T3 Officers, responsible for the oversight of events and initiatives of The Club and coordination of the various offerings and initiatives of The Club.
+
+3.2 Membership of the T5 Officers shall be made up of:
+
+- President
+- Secretary
+- Treasurer
+- Vice President (Mechatronics)
+- Vice President (Robotics)
+
+3.3 The T5 Officers are a subset of the Executive Team, and thus follow the same election process.
+
+3.4 The T5 Officers shall meet once per calendar month, offset from any meeting of the Executive Team by at least seven (7) days. The quorum of such meetings shall be four (4).
+
+## 4 Executive Team
+
+4.1 The Executive Team is the overall leadership body of The Club, directly producing and operating the various offerings and initiatives of The Club.
+
+4.2 Membership of the Executive Team shall be made up of:
+
+- President
+- Secretary
+- Treasurer
+- Vice President (Mechatronics)
+- Vice President (Robotics)
+- Partnerships Lead 
+- Marketing Lead 
+- Technical Lead 
+- Workshops Lead
+- Competitions Lead
+- Events Lead
+- Outreach Lead
+- Projects Lead
+
+4.3 The Executive Team are elected by Club Members at General Meetings of The Club, as outlined by The Constitution.
+
+4.4 The Executive Team shall meet once per calendar month as called by the Secretary.
+
+4.5 Invitations may be extended to all other members of the Management Committee to attend the meetings of the Executive Team, although they shall hold no voting rights.
+
+## 5 Martian Council
+
+5.1 The Martian Council is an advisory body, set up to ensure that the interests of Club Members are heard and enacted.
+
+5.2 Membership of the Martian Council shall be made up of:
+
+- President
+- Secretary
+- Treasurer
+- One (1) Club Member representing each of the following demographics:
+    - Electrical Engineering Students
+    - Mechanical Engineering Students
+    - Software Engineering Students
+    - Female Students
+    - First Year Students
+    - Postgraduate Students
+
+5.3 The representative positions cannot be members of the Executive Team.
+
+5.4 The term of each representative shall be One (1) Calendar Year between elections.
+
+5.5 A limit of Two (2) terms shall be imposed upon representatives of the Martian Council.
+
+5.6 Nominations for the representative roles are to open within 48 hours of the close of the Annual General Meeting of The Club each year, and remain open until 11:59 pm on the 30th day of November that same year.
+
+5.7 Election of the representatives shall be held during the December meeting of the Management Committee, with the voting system left to the discretion of the President, who shall manage the votes.
+
+5.8 The term of representatives shall be that of the calendar year following their election.
+
+5.9 Representatives may resign from their post by written notice to the Secretary no less than fourteen (14) days in advance of their departure, at which time a casual vacancy be opened.
+
+5.10 In the event of a casual vacancy, nominations for the open role shall be released to Club Members for a period of seven (7) days, with the successor to be elected at the first meeting to be held by following the closure of nominations by any of the following bodies: the Management Committee, the T5 Officers, or the Executive Team.
+
+5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
+
+<!-- Further consider first year, may need alternative arrangements -->
+
+## 6 Mechatronics Society Management Team
+
+6.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
+
+- engage Club Members enrolled in the study of mechatronic engineering or a related discipline amongst their peers, The University, and the wider industry
+- provide events and opportunities for Club Members to develop employable skills
+
+6.2 Membership of the Society Team shall be made up of:
+
+- Vice President (Mechatronics)
+- Workshops Lead
+- Competitions Lead
+- Events Lead
+- Outreach Lead
+- Any such number of appointed Officers
+
+6.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
+
+## 7 Robotics Club Management Team
+
+6.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
+
+- provide Club Members with industry-ready technical experiences
+- provide opportunities for Club Members to compete at higher level robotics competitions
+
+6.2 Membership of the Society Team shall be made up of:
+
+- Vice President (Robotics)
+- Projects Lead
+- Robowars Administrative Lead
+- Robowars Technical Lead
+- Any such number of appointed Officers
+
+6.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.

--- a/Regulations.md
+++ b/Regulations.md
@@ -2,7 +2,9 @@
 
 This revision of the regulations is enacted and valid as of this 10th day of October, 2024.
 
-These regulations are supplementary to The Constitution. In the event that there are any contradictions between these Regulations and The Constitution, then The Constitution shall take precedence.
+These regulations are supplementary to The Constitution, with the purpose to standardise the interpretation of The Constitution. Any Regulations created should have little to no impact upon Club Members who do not belong to the Management Committee outside that which The Constitution already impacts.
+
+In the event that there are any contradictions between these Regulations and The Constitution, then The Constitution shall take precedence. In such a case, these Regulations should be revised.
 
 ---
 
@@ -20,7 +22,9 @@ Within this document, the following definitions will be used:
 
 ## Sections found in the Regulations
 
-- [Section 1: Bodies of The Club](#section-1:-bodies-of-the-club)
+- [Section 1: Bodies of The Club](#section-1-bodies-of-the-club)
+- [Section 2: Amendments to Regulations](#section-2-amendments-to-regulations)
+- [Section 3: General Meetings and Executive Elections](#section-3-general-meetings-end-executive-elections)
 
 ---
 
@@ -154,12 +158,12 @@ Within this document, the following definitions will be used:
 
 ## 7 Robotics Club Management Team
 
-6.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
+7.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
 
 - provide Club Members with industry-ready technical experiences
 - provide opportunities for Club Members to compete at higher level robotics competitions
 
-6.2 Membership of the Society Team shall be made up of:
+7.2 Membership of the Society Team shall be made up of:
 
 - Vice President (Robotics)
 - Projects Lead
@@ -167,4 +171,38 @@ Within this document, the following definitions will be used:
 - Robowars Technical Lead
 - Any such number of appointed Officers
 
-6.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
+7.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
+
+# Section 2: Amendments to Regulations
+
+## 8 Amendments to the Regulations
+
+8.1 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Executive Team for the Secretary to include as a motion at a quorate meeting of the Executive Team, which can be passed by simple majority.
+
+8.2 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Martian Council for the Secretary to include as a motion for a quorate meeting of the Martian Council, which can be passed through unanimous vote.
+
+8.3 Amendments to The Regulations can be proposed by Club Members as a Special Resolution to be discussed at a General Meeting in line with The Constitution.
+
+8.4 When Amendments are made, it is the duty of the Secretary to notify all current members of the Management Committee of the update.
+
+8.5 Amendments to the Regulations shall not take effect until the closure of the meeting in which they are passed.
+
+# Section 3: General Meetings and Executive Elections
+
+## 9 Elections of the Executive Team
+
+9.1 At the Annual General Meeting of The Club, the method by which the Executive Team is elected shall be that of a secret ballot.
+
+9.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
+
+9.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
+
+## 10 Election of the Returning Officer
+
+10.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+
+10.2 The Returning Officer does not need to be a Club Member.
+
+10.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
+
+10.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.

--- a/Regulations.md
+++ b/Regulations.md
@@ -197,12 +197,46 @@ Within this document, the following definitions will be used:
 
 9.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
 
-## 10 Election of the Returning Officer
+## 10 Order of Elections
 
-10.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+10.1 At a General Meeting of The Club where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
 
-10.2 The Returning Officer does not need to be a Club Member.
+1. T3 Officers
+2. T5 Officers
+3. Executive Team
 
-10.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
+10.2 Where a role resides in multiple bodies, they shall be elected as part of the first body to which they belong.
 
-10.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.
+10.3 The order of election of the T3 Officers shall be as follows:
+
+1. President
+2. Secretary
+3. Treasurer
+
+10.4 The order of election of the T5 Officers shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+
+1. Vice President (Mechatronics)
+2. Vice President (Robotics)
+
+10.5 The order of election of the Executive Team shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+
+1. Marketing Lead
+2. Partnerships Lead
+3. Technical Lead
+4. Competitions Lead
+5. Workshops Lead
+6. Projects Lead
+7. Outreach Lead
+8. Events Lead
+
+10.6 In this section, "advance nominations" refers to the nominations that can be submitted in advance of the general meeting and excludes those that would be presented from the floor.
+
+## 11 Election of the Returning Officer
+
+11.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+
+11.2 The Returning Officer does not need to be a Club Member.
+
+11.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
+
+11.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.

--- a/Regulations.md
+++ b/Regulations.md
@@ -24,7 +24,7 @@ Within this document, the following definitions will be used:
 
 - [Section 1: Bodies of The Club](#section-1-bodies-of-the-club)
 - [Section 2: Amendments to Regulations](#section-2-amendments-to-regulations)
-- [Section 3: General Meetings and Executive Elections](#section-3-general-meetings-end-executive-elections)
+- [Section 3: General Meetings and Executive Elections](#section-3-general-meetings-and-executive-elections)
 
 ---
 

--- a/Regulations.md
+++ b/Regulations.md
@@ -40,6 +40,7 @@ Within this document, the following definitions will be used:
 - T5 Officers
 - Executive Team (as described by The Constitution)
 - Martian Council
+- MARS Central Management Team
 - Mechatronics Society Management Team
 - Robotics Club Management Team
 
@@ -138,87 +139,103 @@ Within this document, the following definitions will be used:
 
 <!-- Further consider first year, may need alternative arrangements -->
 
-## 6 Mechatronics Society Management Team
+## 6 MARS Central Management Team
 
-6.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
+6.1 The MARS Central Management Team (hereon referred to as the "Central Team") are a body responsible for providing the core services needed to allow and enhance the other events, teams, and initiatives provided by The Club.
+
+6.2 Membership of the Central Team shall be made up of:
+
+- President
+- Secretary
+- Treasurer
+- Marketing Lead
+- Partnerships Lead
+- Technical Lead
+- Any such number of appointed Officers to support the Leads
+
+6.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
+
+## 7 Mechatronics Society Management Team
+
+7.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
 
 - engage Club Members enrolled in the study of mechatronic engineering or a related discipline amongst their peers, The University, and the wider industry
 - provide events and opportunities for Club Members to develop employable skills
 
-6.2 Membership of the Society Team shall be made up of:
+7.2 Membership of the Society Team shall be made up of:
 
 - Vice President (Mechatronics)
 - Workshops Lead
 - Competitions Lead
 - Events Lead
 - Outreach Lead
-- Any such number of appointed Officers
+- Any such number of appointed Officers to support the Leads
 
-6.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
+7.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
 
-## 7 Robotics Club Management Team
+## 8 Robotics Club Management Team
 
-7.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
+8.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
 
 - provide Club Members with industry-ready technical experiences
 - provide opportunities for Club Members to compete at higher level robotics competitions
 
-7.2 Membership of the Society Team shall be made up of:
+8.2 Membership of the Society Team shall be made up of:
 
 - Vice President (Robotics)
 - Projects Lead
 - Robowars Administrative Lead
 - Robowars Technical Lead
-- Any such number of appointed Officers
+- Any such number of appointed Officers to support the Leads
 
-7.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
+8.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
 
 # Section 2: Amendments to Regulations
 
-## 8 Amendments to the Regulations
+## 9 Amendments to the Regulations
 
-8.1 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Executive Team for the Secretary to include as a motion at a quorate meeting of the Executive Team, which can be passed by simple majority.
+9.1 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Executive Team for the Secretary to include as a motion at a quorate meeting of the Executive Team, which can be passed by simple majority.
 
-8.2 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Martian Council for the Secretary to include as a motion for a quorate meeting of the Martian Council, which can be passed through unanimous vote.
+9.2 Amendments to The Regulations can be proposed with no less than seven (7) days notice by members of the Martian Council for the Secretary to include as a motion for a quorate meeting of the Martian Council, which can be passed through unanimous vote.
 
-8.3 Amendments to The Regulations can be proposed by Club Members as a Special Resolution to be discussed at a General Meeting in line with The Constitution.
+9.3 Amendments to The Regulations can be proposed by Club Members as a Special Resolution to be discussed at a General Meeting in line with The Constitution.
 
-8.4 When Amendments are made, it is the duty of the Secretary to notify all current members of the Management Committee of the update.
+9.4 When Amendments are made, it is the duty of the Secretary to notify all current members of the Management Committee of the update.
 
-8.5 Amendments to the Regulations shall not take effect until the closure of the meeting in which they are passed.
+9.5 Amendments to the Regulations shall not take effect until the closure of the meeting in which they are passed.
 
 # Section 3: General Meetings and Executive Elections
 
-## 9 Elections of the Executive Team
+## 10 Elections of the Executive Team
 
-9.1 At the Annual General Meeting of The Club, the method by which the Executive Team is elected shall be that of a secret ballot.
+10.1 At the Annual General Meeting of The Club, the method by which the Executive Team is elected shall be that of a secret ballot.
 
-9.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
+10.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
 
-9.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
+10.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
 
-## 10 Order of Elections
+## 11 Order of Elections
 
-10.1 At a General Meeting of The Club where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
+11.1 At a General Meeting of The Club where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
 
 1. T3 Officers
 2. T5 Officers
 3. Executive Team
 
-10.2 Where a role resides in multiple bodies, they shall be elected as part of the first body to which they belong.
+11.2 Where a role resides in multiple bodies, they shall be elected as part of the first body to which they belong.
 
-10.3 The order of election of the T3 Officers shall be as follows:
+11.3 The order of election of the T3 Officers shall be as follows:
 
 1. President
 2. Secretary
 3. Treasurer
 
-10.4 The order of election of the T5 Officers shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+11.4 The order of election of the T5 Officers shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
 
 1. Vice President (Mechatronics)
 2. Vice President (Robotics)
 
-10.5 The order of election of the Executive Team shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+11.5 The order of election of the Executive Team shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
 
 1. Marketing Lead
 2. Partnerships Lead
@@ -229,14 +246,14 @@ Within this document, the following definitions will be used:
 7. Outreach Lead
 8. Events Lead
 
-10.6 In this section, "advance nominations" refers to the nominations that can be submitted in advance of the general meeting and excludes those that would be presented from the floor.
+11.6 In this section, "advance nominations" refers to the nominations that can be submitted in advance of the general meeting and excludes those that would be presented from the floor.
 
-## 11 Election of the Returning Officer
+## 12 Election of the Returning Officer
 
-11.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+12.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
 
-11.2 The Returning Officer does not need to be a Club Member.
+12.2 The Returning Officer does not need to be a Club Member.
 
-11.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
+12.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
 
-11.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.
+12.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.


### PR DESCRIPTION
In order to effectively capture and publicly convey the current interpretation of the constitution that is held and observed by the executive team, I believe it would be worthwhile to adopt a set of Regulations that can act as an intermediary level of documentation to exist between the constitution and the actions of the executive.

The benefits to doing this are:
1. Transparency with members
2. Consistency between executive teams
3. Mandates active change (that is, if process is changed, it requires active effort and thought from the team)

While it does add a layer of bureaucracy, it is far less so than were these points added to the constitution directly.