### PR TITLE
Historical Update of UQ MARS / UQ Robotics Executives

### DIFF
--- a/Exec.md
+++ b/Exec.md
@@ -128,3 +128,109 @@ This document contains a list of all club executives on record.
 - Matthew Cook
 - Nicole Harding
 - Anastacia Laczko
+
+## 2019 Executive Team
+
+### T3
+
+- ***President:*** Cameron Stroud
+- ***Secretary:*** Raghav Mishra
+- ***Treasurer:*** Bruce Xu
+
+### Rest of Team
+
+- Andrew Czarnuszewicz
+- Anastacia Laczko
+- Juan Palacio Lustra
+
+## 2018 Executive Team
+
+### T4
+
+- ***President:*** Bradley King
+- ***Vice President:*** Andrew Czarnuszewicz
+- ***Secretary:*** Lachlan Healey
+- ***Treasurer:*** Anna Truffet
+
+### Rest of Team
+
+*None / Unknown*
+
+## 2017 Executive Team
+
+### T4
+
+- ***President:*** Tim Hadwen
+- ***Vice President:*** Iain Rudge
+- ***Secretary:*** Nicholas Buckeridge
+- ***Treasurer:*** Declan Vong
+
+### Rest of Team
+
+- Ryan Boyle
+
+## 2016 Executive Team
+
+### T4
+
+- ***President:*** Tim Hadwen
+- ***Vice President:*** Iain Rudge
+- ***Secretary:*** Michael Smith
+- ***Treasurer:*** Aiden Harvey
+
+### Rest of Team
+
+- Ryan Boyle
+- Kieren Chiang
+- Cobus Hoffmann
+- Liam McBride-Kelly
+
+## 2015 Executive Team
+
+### T3
+
+- ***President:*** Tharun Sonti
+- ***Secretary:*** Unknown
+- ***Treasurer:*** William Wu
+
+### Rest of Team
+
+- Lex Van Cooten
+- Peter Photinos
+- Fabian Vasuain
+
+## 2014 Executive Team
+
+### T3
+
+- ***President:*** Peter Photinos
+- ***Secretary:*** Will Toohey
+- ***Treasurer:*** William Wu
+
+### Rest of Team
+
+- Lex Van Cooten
+
+## 2013 Executive Team
+
+### T3
+
+- ***President:*** Kit Ham
+- ***Secretary:*** Unknown
+- ***Treasurer:*** Unknown
+
+### Rest of Team
+
+- Lex Van Cooten
+
+## 2012 Executive Team
+
+### T3
+
+- ***President:*** Erin McColl
+- ***Secretary:*** Kit Ham
+- ***Treasurer:*** Unknown
+
+### Rest of Team
+
+*None / Unknown*

--- a/Exec.md
+++ b/Exec.md
@@ -143,6 +143,8 @@ This document contains a list of all club executives on record.
 - Anastacia Laczko
 - Juan Palacio Lustra
 
+***This marks the point in history where UQ Robotics became the UQ Mechatronics and Robotics Society (UQ MARS)***
+
 ## 2018 Executive Team
 
 ### T4

--- a/Exec.md
+++ b/Exec.md
@@ -6,138 +6,125 @@ This document contains a list of all club executives on record.
 
 ## 2025 Executive Team
 
-### T3
+### T5
 
-President: Quinn Horton
-
-Secretary: Binara Wasala
-
-Treasurer: Samantha Krause
+- ***President:*** Quinn Horton
+- ***Secretary:*** Binara Wasala
+- ***Treasurer:*** Samantha Krause
+- ***Vice President (Mechatronics):*** Phillip Reid
+- ***Vice President (Robotics):*** Slater Sammut
 
 ### Rest of Team
 
-* Zac Apelt
-* Alana Cawthorne
-* Joseph Hatcliff
-* Shaariq Jaldin
-* Oscar Lloyd
-* Erin McGrath
-* Ethan Ney
-* Phillip Reid
-* Slater Sammut
-* Ganesh Srinivasa
+- Zac Apelt
+- Alana Cawthorne
+- Joseph Hatcliff
+- Shaariq Jaldin
+- Oscar Lloyd
+- Erin McGrath
+- Ethan Ney
+- Ganesh Srinivasa
 
 ## 2024 Executive Team
 
 ### T3
 
-President: Quinn Horton
-
-Treasurer: Slater Sammut
-
-Secretary: Jay Hunter (Resigned at SGM, February 20, 2024)
-
-Secretary: Mac Rogers (Elected at SGM, February 20, 2024)
+- ***President:*** Quinn Horton
+- ***Secretary:*** Jay Hunter (Resigned at SGM, February 20, 2024)
+- ***Secretary:*** Mac Rogers (Elected at SGM, February 20, 2024)
+- ***Treasurer:*** Slater Sammut
 
 ### Rest of Team
 
-* Sara Alaei
-* Rafay Anwar
-* Zac Apelt
-* Yogansh Bhalla
-* Jet Garcia (Resigned in January, 2024)
-* Jay Hunter (Elected at SGM, February 20, 2024; Resigned August 18, 2024)
-* Oscar Lloyd (Appointed to fill casual vacancy, September 11, 2024)
-* Shwethank Nampalli (Resigned on February 22, 2024)
-* Ethan Ney (Elected at SGM, February 20, 2024)
-* Josh Penner
-* Luke Pidgeon
-* Phillip Reid (Appointed to fill casual vacancy, March 2, 2024)
-* Mac Rogers (Until SGM, February 20, 2024)
-* Alexander Strang
-* Benjamin Tran
-* Binara Wasala
+- Sara Alaei
+- Rafay Anwar
+- Zac Apelt
+- Yogansh Bhalla
+- Jet Garcia (Resigned in January, 2024)
+- Jay Hunter (Elected at SGM, February 20, 2024; Resigned August 18, 2024)
+- Oscar Lloyd (Appointed to fill casual vacancy, September 11, 2024)
+- Shwethank Nampalli (Resigned on February 22, 2024)
+- Ethan Ney (Elected at SGM, February 20, 2024)
+- Josh Penner
+- Luke Pidgeon
+- Phillip Reid (Appointed to fill casual vacancy, March 2, 2024)
+- Mac Rogers (Until SGM, February 20, 2024)
+- Alexander Strang
+- Benjamin Tran
+- Binara Wasala
 
 ## 2023 Executive Team
 
 ### T3
 
-President: Jay Hunter
-
-Treasurer: Quinn Horton
-
-Secretary: Reuben Richardson
+- ***President:*** Jay Hunter
+- ***Secretary:*** Reuben Richardson
+- ***Treasurer:*** Quinn Horton
 
 ### Rest of Team
 
-* Alnmad Alnmad
-* Ella Bazin
-* Shanker Dorairajan
-* Jet Garcia
-* Joshua Lai
-* Ash Masame
-* Shwethank Nampalli
-* Francisco Prado
-* Slater Sammut
-* Hokul Srikanthan
-* Benjamin Tran
-* Miguel Valencia
-* Binara Wasala
-* Kelly Zhou
+- Alnmad Alnmad
+- Ella Bazin
+- Shanker Dorairajan
+- Jet Garcia
+- Joshua Lai
+- Ash Masame
+- Shwethank Nampalli
+- Francisco Prado
+- Slater Sammut
+- Hokul Srikanthan
+- Benjamin Tran
+- Miguel Valencia
+- Binara Wasala
+- Kelly Zhou
 
 ## 2022 Executive Team
 
 ### T3
 
-President: Joshua Lai
-
-Treasurer: Jay Hunter
-
-Secretary: Shanker Dorairajan
+- ***President:*** Joshua Lai
+- ***Secretary:*** Shanker Dorairajan
+- ***Treasurer:*** Jay Hunter
 
 ### Rest of Team
 
-* Alnmad Alnmad
-* Konrad Born
-* Matthew Cook
-* Ash Masame
-* Benjamin von Snarski
-* Kelly Zhou
+- Alnmad Alnmad
+- Konrad Born
+- Matthew Cook
+- Ash Masame
+- Benjamin von Snarski
+- Kelly Zhou
 
 ## 2021 Executive Team
 
 ### T3
 
-President: Joshua Lai
-
-Treasurer: Callum Breetzke
-
-Secretary: Nicole Harding
+- ***President:*** Joshua Lai
+- ***Secretary:*** Nicole Harding
+- ***Treasurer:*** Callum Breetzke
 
 ### Rest of Team
 
-* Konrad Born
-* Riley Bowyer
-* Matthew Cook
-* Harsha Joshi
-* Anastasia Laczko
-* Benjamin von Snarski
+- Konrad Born
+- Riley Bowyer
+- Matthew Cook
+- Harsha Joshi
+- Anastasia Laczko
+- Benjamin von Snarski
 
 ## 2020 Executive Team
 
 ### T3
 
-President: Cameron Stroud
-
-Treasurer: Keith Cunningham
-
-Secretary: Nick Jones
+- ***President:*** Cameron Stroud
+- ***Secretary:*** Nick Jones
+- ***Treasurer:*** Keith Cunningham
 
 ### Rest of Team
 
-* Konrad Born
-* Riley Bowyer
-* Callum Breetzke
-* Matthew Cook
-* Nicole Harding
-* Anastacia Laczko
+- Konrad Born
+- Riley Bowyer
+- Callum Breetzke
+- Matthew Cook
+- Nicole Harding
+- Anastacia Laczko


### PR DESCRIPTION
# Summary of Review into Past MARS Exec

This PR summarises, with sources, the newly found historical summary of executive members of UQ MARS / UQ Robotics. These are compiled in the code changed, then the derivations / reasoning are broken down by source as follows.

## Acknowledgements

I would like to thank @Binary-Designer and @ThatSealgair for having reviewed the findings prior to this publication. If there are any others who have been previously involved who notice discrepancies or oversights, or are happy to validate the findings in the information presented, please leave a comment on this pull request to share. These changes will not be merged until they have been ratified by resolution of the members at a general meeting.

## Meeting Minutes

The following meeting minutes, progressing in reverse chronological order, demonstrate points that introduce additional information about past executives. Where minutes do not contribute to this, they are not recorded here.

### 2019/02/28

- President: Cameron [Stroud]
- Secretary: Raghav [Mishra]
- Treasurer: Bruce [?]

### 2019/02/17

Confirms Bruce to be Bruce Xu

### 2019/01/17

In attendance, Andrew [?]

### 2018/10/31

Note Taker noted as Andrew Carson

Also present: Anastasia and Juan

### 2017-AGM-Minutes

Michael Smith elected returning officer

Bradley King retracts nomination for Secretary

## Old Emails

The `uqrobotics@gmail.com` email address has, by all appearances, been operational since the inception of the association in 2012. The following will detail relevant email from these that may reveal further information on the past executive of the association.

### 'UQ Robotics Meeting' - 29/04/2012

This is the first email to be signed off "Kit".

### 'UQ Robotics Meeting' - 15/09/2012

An excerpt from this email states: "So our president, Erin McColl, has informed me that we need to start thinking about electing exec."

This email is signed off by "Kit"

### "Info Request" - 27/01/2013

An excerpt from this email states: "Our very own treasurer isn't an engineer, she's doing IT+business."

## Other Club Documents

This will detail any other documents that might lend to other history of exec.

### 2019 Financial Returns

Treasurer name: Juan Palacio Lustra

### 'Current Projects' Google Doc from 2017

Under the workshops section, includes:
> CV (Iain, ~Declan)

### 'UQRobotics AGM 2017 Nominations (Responses)' Google Sheet

- President: Timmy Hadwen
- Vice President: Iain Rudge
- Marketing Manager: Ryan Boyle

### 2017 > 'Exec Noms' Google Sheet

- President: Bradley King
- Secretary: Leggy, Lord of Ducks
- Treasurer: Anna Truffet

## LinkedIn

### Tim Hadwen

SRC: https://www.linkedin.com/in/tim-hadwen-53863185/

President, 2016 and 2017

### Raghav Mishra

SRC: https://www.linkedin.com/in/lavieestdure/

Partnerships Director, Executive Comittee Member, 2019

### Cameron Stroud

SRC: https://www.linkedin.com/in/cstroud/

President, 2019 and 2020

### Bruce Xu

SRC: https://www.linkedin.com/in/bruce-xu-b02201107/

Vice President, 2019

### Iain Rudge

SRC: https://www.linkedin.com/in/iain-rudge-394653154/

Vice President, 2015-2017

### Lex Van Cooten

SRC: https://www.linkedin.com/in/lexvc/

Project Manager, 2013 and 2014

### Tharun Sonti

SRC: https://www.linkedin.com/in/tharun-sonti/

President, 2015

### William Wu

SRC: https://www.linkedin.com/in/williamwuofficial/

Treasurer, July 2014 - Nov 2015

### Declan V

SRC: https://www.linkedin.com/in/declan-v-323264a4/

Treasurer, 2017

### Kieren C

SRC: https://www.linkedin.com/in/kierenchiang/

Committee Member, Coordinator, N.D. at UQ Robotics

### Christopher Ham

SRC: https://www.linkedin.com/in/christopher-ham-480a3b25/

Lists 'President of UQ Robotics Club' during 2009 - 2012 bachelor degree enrolment. Also lists a PhD at UQ under experience from 2013 to 2018.

## Other Online Sources

### Robotics to aid amputees - YouTube

SRC: https://www.youtube.com/watch?v=wMS5a3N_fKc

Uploaded September, 2015

Project Manager: Lex Van Cooten

### Now printing: prosthetic limbs, UQ Article from 2015

SRC: https://www.uq.edu.au/news/article/2015/09/now-printing-prosthetic-limbs

Lists member Fabian Vasuain as head engineer

### 2015 UQ Robotics Website

SRC: https://web.archive.org/web/20150825021847/http://uqrobotics.com/

Event listings for S2, 2015 appear to be prepended by names:
- Tharun Sonti
- Lex
- Meetkumar
- Liam
- Joshua
- Will
- Peter

### UQ MARS Facebook Page

SRC: https://www.facebook.com/UQMARS/

In going into past posts logged in and viewing as the UQ MARS page, it shows who posted each post, the following were caught going back year by year:
- Andrew Czarnuszewicz, 2018
- Bradley King, 2018
- Ryan Boyle, 2017, 2016
- Timmy Hadwen, 2017, 2016
- IFTTT, 2016
- Kieren Chiang, 2016
- Tharun Sonti, 2015
- William Wu, 2015
- Jojo Chan, 2015
- Peter Photinos, 2015, 2014
- Kit Ham, 2014

Individual account names are not listed on posts prior to this.

SRC: https://www.facebook.com/share/p/1BZugrNi2z/

Congratulatory post from January 22, 2015 naming Tharun Sonti as president

SRC: https://www.facebook.com/share/p/1NXRiAE1Pa/

A post from July 9, 2014 announcing the election of executives:
- President: Peter Photinos
- Secretary: Will Toohey
- Treasurer: William Wu

SRC: https://www.facebook.com/photo/?fbid=299628970104981&set=a.299628963438315

The first post on the Facebook page dated Feb 27, 2012 contains a poster with two contacts:
- Erin McColl
- Marnie Lamprecht

### UQ MARS Discussion Group - FB Group

SRC: https://www.facebook.com/share/p/1Lu627TA91/

Announcement of 2018 executive from Timmy Hadwen, which declares:
- President - Bradley King
- Vice President - Andrew Czarnuszewicz
- Secretary - Lachlan Healey
- Treasurer - Anna Truffet

Also, acknowledges the 2017 exec:
- Iain Rudge
- Ryan Boyle
- Declan Vong
- Nicholas Buckeridge

SRC: https://www.facebook.com/share/p/1AE1aX5sk2/

Announcement of 2017 executive from Timmy Hadwen, which declares:
- Timmy Hadwen - President
- Iain Rudge - Vice President
- Declan Vong - Treasurer
- Nicholas Buckeridge - Secretary
- Ryan Boyle - VP of Marketing

SRC: https://www.facebook.com/share/p/15weS2nZw2/

Announcement of 2016 executive from William Wu (who signed off as ex-treasurer), which declares:
- President: Timmy Hadwen
- Vice-President: Iain Rudge
- Secretary: Michael Smith
- Treasurer: Aiden Harvey

Joining them will also be 3 people, in the management committee:
Liam McBride-Kelly, Cobus Hoffmann, Kieren Chiang

SRC: https://www.facebook.com/share/p/1CexJ4Uc7Y/

Post from Erin McColl which appears to establish the inception of UQ Robotics / UQ MARS

### 2013 staff contact page for METR3800/METR4810

SRC: https://metr4810.uqcloud.net/2013/contacts.html

Connects Kit Ham to an email address with the name Christopher Ham.

## Conclusions

This information details some of the conclusions arrived at to generate the lists, some of which are not explicitly listed. This may also refer to information which has not explicitly been included above, but might have been witnessed during the search.

### 2019 Executives

As there appear to be competing details on who the treasurer was during this period, I would be inclined to think that the one named in February, Bruce, held the title and that the one named on the financial returns, Juan, performed the duties as acting treasurer. As the name also appeared as present in a meeting at the end of 2018, it is suspected that they did so as a general executive. The Anastasia who is also noted as present is believed to be Anastacia Laczko who is recorded as having been an executive in 2020 and 2021, with the timeline validated by their LinkedIn stating their enrolment beginning in 2016. The remainder of the team was settled by the attendance lists during the meeting minutes.

### 2014 through 2018 executives

While these are not really speculative, it should be noted that the years of 2016 through 2018 are directly adapted from the announcements made in the discussion groups. Likewise, the 2014 T3 and 2015 president are taken from the announcements on the MARS FB page. The 2015 treasurer is taken from the 2016 executive announcement and corroborated by LinkedIn. The addition of Lex and Fabian come from the UQ Article and some Facebook posts.

### Kit Ham's involvement

There is clearly involvement from Kit Ham which ranges from 2012 to 2014 from the Facebook and emails. My suspicion in reviewing these is that they were president for a stretch, but not as part of their undergraduate listed on their LinkedIn, given the email they themselves sent which names Erin as having been president at that time. A post that they made in 2014 stated that they would not be able to helm the club that year, which I interpret to mean that they were president the preceding year (2013). Given that their name also frequently appeared as the signatory on early emails reviewed from 2012-2013 including naming their predecessor, I suspect that they were likely the Secretary in 2012.