### PR TITLE
Minor change to AGM timing

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -194,7 +194,7 @@ This revision of the constitution is enacted and valid on this 10th day of Octob
 * at least once each year
 * within three (3) months after the end of The Association's previous financial year.
 
-16.2 The annual general meeting will be held in the month of October each year.
+16.2 The annual general meeting will be held before the end of the month of October each year.
 
 ## 17 BUSINESS TO BE TRANSACTED AT ANNUAL GENERAL MEETING
 


### PR DESCRIPTION
This is a relatively inconsequential change that allows the executive to schedule the AGM slightly earlier in a given year. Generally we will need to have had any financial reviews done prior to the AGM, but outside of that there's no reason that the AGM shouldn't be permitted to run in late September.