### PR TITLE
Submit Joshua Lai for Life Membership

### DIFF
--- a/Life-Members.md
+++ b/Life-Members.md
@@ -5,4 +5,5 @@ Per Section 27 of the constitution, life membership is an honourary title that m
 | Full Name | Time of Award |
 | ----- | ----- |
 | Tim Hadwen | 2024 SGM |
+| Joshua Lai | 2025 AGM |
 


### PR DESCRIPTION
As the end of the year arrives, and with it comes another AGM, I would like to submit for consideration Joshua Lai to be named a Life Member of UQ MARS.

Per section 27.3 of our constitution, there are two hard requirements for those being named Life Members, both of which Josh meets:
- Must have previously been a member of the Executive Team
- Must not have been a member of the Executive Team within the past two (2) calendar years

Of course, these in and of themselves are not the only thing to set someone up to be a life member, the more influential term is that "This title is intended to honour those that have made significant contributions to The Club and have since remained close to it."

While this is not necessarily a pattern to instil for all life members, Josh did serve two consecutive terms as president, which is far from a simple feat. Particularly, these terms were in 2021 and 2022 which was a difficult time for all student groups, recovering and rebuilding in numbers after (and somewhat through 2021) the COVID lockdowns, speaking to the work that was done at that time for MARS to be in the position that we are now. As someone who started my studies in 2021, I recall how much less presence there was on campus at the time given that remote studies were still running, the borders were still only just reopening, and there were still COVID-related measures in place everywhere (I ended up isolating or in lockdown multiple times that year) - I can be confident that the efforts it took to just keep the society running with regular events of any type was a feat.

I personally started to engage with MARS in 2022, and I can say that Josh was quite a welcoming presence. I recall joining one of the teams for DRC at the time and having a fairly impromptu Discord call with a few of the members on various teams that ended up being Josh spending an hour or so off-the-cuff running through getting started with OpenCV.

Of course, these were not solo efforts and there were other exec who contributed to the success at the time, but they do certainly speak to Josh's own efforts.

On the other point regarding remaining close to MARS, Josh has continued to attend events and offer support since hanging up the presidency at the end of 2022 and then subsequently bowing out as a general exec in mid-2023. He stepped back in to help run the ROS workshops in 2023 and 2024, served as the Returning Officer for our AGM in 2023, and has been to a couple launch parties and networking nights since, as well as more broadly keeping involved and continuing to pass down knowledge.

Ultimately, I think that Josh is a great example of someone who has given a lot to the society and deserves to be recognised for it.