### PR TITLE
Update Aims and Objectives

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -31,8 +31,10 @@ This revision of the constitution is enacted and valid on this 10th day of Octob
 3.1 The aims of The Association are:
 
 * to bring members of The University community interested in or studying mechatronics and robotics together to form a dedicated society
-* to provide a relaxed club and environment where students who have no experience will be provided resources and the expertise of more experience, giving them the ability to build their own mechatronic systems
-* to provide a centralised group for enthusiasts who may wish to compete on behalf of The University at higher level robotics competitions
+* to represent and advocate for the academic interests of students enrolled in mechatronics or its composite disciplines
+* to provide a welcoming environment which encourages and enables learning within the fields of mechatronics and robotics for all skill levels
+* to provide a centralised group for enthusiasts who may wish to work on electronic, mechanical, and robotics projects, and compete on behalf of The University at higher level robotics competitions
+* to provide opportunities for members to network and form connections with members of the mechatronics and robotics community
 
 3.2 Non-Profit Clause: The assets and income of The Association shall be applied solely in furtherance of its abovementioned objects and no portion shall be distributed directly or indirectly to the members of The Association except as bona fide compensation for services rendered or expenses incurred on behalf of The Association.
 


### PR DESCRIPTION
NOTE: I only intend to move this with the approval / endorsement of the Clubs and Societies Committee

# Motivations

This section details the motivations behind the update to the aims and objectives of UQ MARS.

## Currency

As with many of the constitutional updates that have been brought to general meetings in the past three years, a strong motivation behind this change is to bring the constitution up to speed with the current operations of our association. By all understanding, the current aims and objectives were set out in 2012 when UQ Robotics was originally formed with only minor wording changes to reflect an inclusion of mechatronics, and does not account for the broader expansions and developments that have occurred in the past 13 years.

## Reflection of Not-for-Profit Cause

The operations of UQ MARS are carried out in a not-for-profit capacity, which while reflected by the blatant ‘Non-Profit Clause’, could be better engineered to reflect the alignment with the definitions and categories set out by the ATO in regards to not-for-profit organisations.

## Enforceability of Purpose

By ensuring that the aims and objectives are up to date, it ensures that there are grounds for members to reinforce the purposes and events which are to be run by the association. This is enabled more by the public hosting of the constitution which is the current precedent.

# Overview of New Aims and Objectives

Drawing from the above information, this section presents and summarises the established aims and objectives which are proposed to be adopted by UQ MARS in 2025.

## Cohort Unification
> To bring members of The University community interested in or studying mechatronics and robotics together to form a dedicated society.

This is pulled directly from the first of the current aims and objectives. This is a fairly fundamental objective and needs no change. This serves to represent the general community and social elements of the association.

## Academic Engagement
> *To represent and advocate for the academic interests of students enrolled in mechatronics or its composite disciplines.*

As a faculty-based society, MARS has been approached in various capacities to represent students in discipline-related academic matters such as program structure. As a faculty-aligned student association with a notable objective to be the go-to place for those in studies in or around mechatronics, there is the implicit expectation that we also represent the collective interests of our members regarding their studies. The goal of introducing this is to make explicit this expectation.

## Educational Offerings
> ~~To provide a relaxed environment where students who have no experience will be provided resources and the expertise of more experience, giving them the ability to build their own mechatronic systems.~~
*To provide a welcoming environment which encourages and enables learning within the fields of mechatronics and robotics for those of all skill levels.*

This has been altered to not discourage more sophisticated levels of educational content. We find that currently there is a wall at early level content with lesser support provided for students after their first year. Given that there is a general revision of the objectives, it’s worth embedding a more holistic approach.

## Development Experience
> To provide a centralised group for enthusiasts who may wish to *work on electronic, mechanical, and robotics projects, and* compete on behalf of The University at higher level robotics competitions.

This has been amended from the current format to account for non-competitive projects focused instead on other forms of project-based experience without the constraints of trying to meet the requirements of a competition. It also includes the other key constituent disciplines of mechatronics to cover specific interests beyond just robotics that otherwise still come under the umbrella of mechatronics. While the mention of electronic and mechanical disciplines may cause concern for overlap with EBESS and MESS, this is purely in regards to project-based work, something not known to be prescribed by their aims or current activity.

## Professional Development
> *To provide opportunities for members to network and form connections with members of the mechatronics and robotics community.*

As we serve the purpose of being a program-oriented student society, there is an expectation that we help in showcasing the pathways that exist within the field. This is worded in a way to keep it broad enough to encompass generally forming connections without explicitly falling under being focused on the professional interests of members, to align with the non-profit requirements for scientific organisations. This also has the benefit of aligning with things like our academic talks which connect students to members of the field, without necessarily being for the purpose of professional advancement.