### PR TITLE
Renumber regs to follow sections

### DIFF
--- a/Regulations.md
+++ b/Regulations.md
@@ -45,7 +45,7 @@ Within this document, the following definitions will be used:
 
 1.1.3 As presented by The Constitution, each body exists as a subcommittee of Association Members.
 
-1.1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.2.
+1.1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.1.2.
 
 ## 1.2 T3 Officers
 
@@ -135,7 +135,7 @@ Within this document, the following definitions will be used:
 
 1.5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
 
-1.5.12 An exclusion to 5.6, 5.7, and 5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
+1.5.12 An exclusion to 1.5.6, 1.5.7, and 1.5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
 
 1.5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election. Their term shall end when their successor commences the following year in line with these Regulations.
 
@@ -236,10 +236,10 @@ Within this document, the following definitions will be used:
 
 ## 2.3 Election of the Returning Officer
 
-2.3.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+2.3.1 Due to 2.1.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
 
 2.3.2 The Returning Officer does not need to be a Association Member.
 
 2.3.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
 
-2.3.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.
+2.3.4 Should a Returning Officer elected in advance as per 2.1.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.

--- a/Regulations.md
+++ b/Regulations.md
@@ -29,11 +29,11 @@ Within this document, the following definitions will be used:
 
 # Section 1: Bodies of The Association
 
-## 1 Management Committee of The Association
+## 1.1 Management Committee of The Association
 
-1.1 The Management Committee of The Association shall be the body responsible for the management of The Association.
+1.1.1 The Management Committee of The Association shall be the body responsible for the management of The Association.
 
-1.2 The Management Committee is to be comprised of the union of members from the following bodies of The Association:
+1.1.2 The Management Committee is to be comprised of the union of members from the following bodies of The Association:
 
 - T3 Officers (as described by The Constitution)
 - T5 Officers
@@ -43,27 +43,27 @@ Within this document, the following definitions will be used:
 - Mechatronics Society Management Team
 - Robotics Club Management Team
 
-1.3 As presented by The Constitution, each body exists as a subcommittee of Association Members.
+1.1.3 As presented by The Constitution, each body exists as a subcommittee of Association Members.
 
-1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.2.
+1.1.4 The Management Committee shall have two meetings per calendar year, held one each during the months of June and December. The quorum of such meetings shall be a simple majority of members of the Management Committee, which must include at least two (2) members of each body listed in 1.2.
 
-## 2 T3 Officers
+## 1.2 T3 Officers
 
-2.1 The T3 Officers shall be the chief administrative body of The Association, responsible for management of The Management Committee, The Association's finances, and for any external commitments of The Association such as to The University or to The Union.
+1.2.1 The T3 Officers shall be the chief administrative body of The Association, responsible for management of The Management Committee, The Association's finances, and for any external commitments of The Association such as to The University or to The Union.
 
-2.2 Membership of the T3 Officers shall be made up of:
+1.2.2 Membership of the T3 Officers shall be made up of:
 
 - President
 - Secretary
 - Treasurer
 
-2.3 The T3 Officers are a subset of the Executive Team, and thus follow the same election process.
+1.2.3 The T3 Officers are a subset of the Executive Team, and thus follow the same election process.
 
-## 3 T5 Officers
+## 1.3 T5 Officers
 
-3.1 The T5 Officers shall be an extension of the T3 Officers, responsible for the oversight of events and initiatives of The Association and coordination of the various offerings and initiatives of The Association.
+1.3.1 The T5 Officers shall be an extension of the T3 Officers, responsible for the oversight of events and initiatives of The Association and coordination of the various offerings and initiatives of The Association.
 
-3.2 Membership of the T5 Officers shall be made up of:
+1.3.2 Membership of the T5 Officers shall be made up of:
 
 - President
 - Secretary
@@ -71,15 +71,15 @@ Within this document, the following definitions will be used:
 - Vice President (Mechatronics)
 - Vice President (Robotics)
 
-3.3 The T5 Officers are a subset of the Executive Team, and thus follow the same election process.
+1.3.3 The T5 Officers are a subset of the Executive Team, and thus follow the same election process.
 
-3.4 The T5 Officers shall meet once per calendar month, offset from any meeting of the Executive Team by at least seven (7) days. The quorum of such meetings shall be four (4).
+1.3.4 The T5 Officers shall meet once per calendar month, offset from any meeting of the Executive Team by at least seven (7) days. The quorum of such meetings shall be four (4).
 
-## 4 Executive Team
+## 1.4 Executive Team
 
-4.1 The Executive Team is the overall leadership body of The Association, directly producing and operating the various offerings and initiatives of The Association.
+1.4.1 The Executive Team is the overall leadership body of The Association, directly producing and operating the various offerings and initiatives of The Association.
 
-4.2 Membership of the Executive Team shall be made up of:
+1.4.2 Membership of the Executive Team shall be made up of:
 
 - President
 - Secretary
@@ -95,17 +95,17 @@ Within this document, the following definitions will be used:
 - Outreach Lead
 - Projects Lead
 
-4.3 The Executive Team are elected by Association Members at General Meetings of The Association, as outlined by The Constitution.
+1.4.3 The Executive Team are elected by Association Members at General Meetings of The Association, as outlined by The Constitution.
 
-4.4 The Executive Team shall meet once per calendar month as called by the Secretary.
+1.4.4 The Executive Team shall meet once per calendar month as called by the Secretary.
 
-4.5 Invitations may be extended to all other members of the Management Committee to attend the meetings of the Executive Team, although they shall hold no voting rights.
+1.4.5 Invitations may be extended to all other members of the Management Committee to attend the meetings of the Executive Team, although they shall hold no voting rights.
 
-## 5 Martian Council
+## 1.5 Martian Council
 
-5.1 The Martian Council is an advisory body, set up to ensure that the interests of Association Members are heard and enacted.
+1.5.1 The Martian Council is an advisory body, set up to ensure that the interests of Association Members are heard and enacted.
 
-5.2 Membership of the Martian Council shall be made up of:
+1.5.2 Membership of the Martian Council shall be made up of:
 
 - President
 - Secretary
@@ -117,33 +117,33 @@ Within this document, the following definitions will be used:
     - First Year Students
     - Postgraduate Students
 
-5.3 Members of the Executive Team shall be ineligible to nominate for a representative role on the council, and representative members of the Martian Council shall only be eligible to nominate for a position on the Executive Team at an Annual General Meeting of The Association.
+1.5.3 Members of the Executive Team shall be ineligible to nominate for a representative role on the council, and representative members of the Martian Council shall only be eligible to nominate for a position on the Executive Team at an Annual General Meeting of The Association.
 
-5.4 The term of each representative shall be One (1) Calendar Year.
+1.5.4 The term of each representative shall be One (1) Calendar Year.
 
-5.5 A limit of Two (2) terms shall be imposed upon representatives of the Martian Council.
+1.5.5 A limit of Two (2) terms shall be imposed upon representatives of the Martian Council.
 
-5.6 Nominations for the representative roles are to open within 48 hours of the close of the Annual General Meeting of The Association each year, and remain open until 11:59 pm on the 30th day of November that same year.
+1.5.6 Nominations for the representative roles are to open within 48 hours of the close of the Annual General Meeting of The Association each year, and remain open until 11:59 pm on the 30th day of November that same year.
 
-5.7 Election of the representatives shall be held during the December meeting of the Management Committee, with the voting system left to the discretion of the President, who shall manage the votes.
+1.5.7 Election of the representatives shall be held during the December meeting of the Management Committee, with the voting system left to the discretion of the President, who shall manage the votes.
 
-5.8 The term of representatives shall be that of the calendar year following their election.
+1.5.8 The term of representatives shall be that of the calendar year following their election.
 
-5.9 Representatives may resign from their post by written notice to the Secretary no less than fourteen (14) days in advance of their departure, at which time a casual vacancy be opened.
+1.5.9 Representatives may resign from their post by written notice to the Secretary no less than fourteen (14) days in advance of their departure, at which time a casual vacancy be opened.
 
-5.10 In the event of a casual vacancy, nominations for the open role shall be released to Association Members for a period of seven (7) days, with the successor to be elected at the first meeting to be held by following the closure of nominations by any of the following bodies: the Management Committee, the T5 Officers, or the Executive Team.
+1.5.10 In the event of a casual vacancy, nominations for the open role shall be released to Association Members for a period of seven (7) days, with the successor to be elected at the first meeting to be held by following the closure of nominations by any of the following bodies: the Management Committee, the T5 Officers, or the Executive Team.
 
-5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
+1.5.11 Meetings of the Martian Council shall be held once per calendar month, with at least seven (7) days notice given by the Secretary. The quorum at such a meeting shall be at least one (1) T3 Officer plus a simple majority of the representative roles.
 
-5.12 An exclusion to 5.6, 5.7, and 5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
+1.5.12 An exclusion to 5.6, 5.7, and 5.8 shall be made for the representative for "First Year Students" to allow for legitimate first years to hold the role, for which position nominations shall open on the second Sunday before classes end for the mid-semester break in Semester One as outlined by the Academic Calendar of The University, and close on the day that classes resume following the mid-semester break.
 
-5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election. Their term shall end when their successor commences the following year in line with these Regulations.
+1.5.13 Election of the representative for "First Year Students" shall take place on the first meeting of the Executive Team following the closure of nominations, with their term to commence from the first meeting of the Martian Council following their election. Their term shall end when their successor commences the following year in line with these Regulations.
 
-## 6 MARS Central Management Team
+## 1.6 MARS Central Management Team
 
-6.1 The MARS Central Management Team (hereon referred to as the "Central Team") are a body responsible for providing the core services needed to allow and enhance the other events, teams, and initiatives provided by The Association.
+1.6.1 The MARS Central Management Team (hereon referred to as the "Central Team") are a body responsible for providing the core services needed to allow and enhance the other events, teams, and initiatives provided by The Association.
 
-6.2 Membership of the Central Team shall be made up of:
+1.6.2 Membership of the Central Team shall be made up of:
 
 - President
 - Secretary
@@ -153,16 +153,16 @@ Within this document, the following definitions will be used:
 - Technical Lead
 - Any such number of appointed Officers to support the Leads
 
-6.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
+1.6.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
 
-## 7 Mechatronics Society Management Team
+## 1.7 Mechatronics Society Management Team
 
-7.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
+1.7.1 The Mechatronics Society Management Team (hereon referred to as the "Society Team") are a body responsible for providing events and initiatives that have the goal to:
 
 - engage Association Members enrolled in the study of mechatronic engineering or a related discipline amongst their peers, The University, and the wider industry
 - provide events and opportunities for Association Members to develop employable skills
 
-7.2 Membership of the Society Team shall be made up of:
+1.7.2 Membership of the Society Team shall be made up of:
 
 - Vice President (Mechatronics)
 - Workshops Lead
@@ -171,16 +171,16 @@ Within this document, the following definitions will be used:
 - Outreach Lead
 - Any such number of appointed Officers to support the Leads
 
-7.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
+1.7.3 The appointment of Officers of the Society Team shall occur through recommendation by the Society Team and subsequent approval from the T5 Officers.
 
-## 8 Robotics Club Management Team
+## 1.8 Robotics Club Management Team
 
-8.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
+1.8.1 The Robotics Club Management Team (hereon referred to as the "Club Team") are a body responsible for establishing and maintatining teams and initiatives that have the goal to:
 
 - provide Association Members with industry-ready technical experiences
 - provide opportunities for Association Members to compete at higher level robotics competitions
 
-8.2 Membership of the Society Team shall be made up of:
+1.8.2 Membership of the Society Team shall be made up of:
 
 - Vice President (Robotics)
 - Projects Lead
@@ -188,39 +188,40 @@ Within this document, the following definitions will be used:
 - Robowars Technical Lead
 - Any such number of appointed Officers to support the Leads
 
-8.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
+1.8.3 The appointment of Officers of the Club Team shall occur through recommendation by the Club Team and subsequent approval from the T5 Officers.
+
 # Section 2: General Meetings and Executive Elections
 
-## 9 Elections of the Executive Team
+## 2.1 Elections of the Executive Team
 
-9.1 At the Annual General Meeting of The Association, the method by which the Executive Team is elected shall be that of a secret ballot.
+2.1.1 At the Annual General Meeting of The Association, the method by which the Executive Team is elected shall be that of a secret ballot.
 
-9.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
+2.1.2 The secret balloting system to be followed shall be that of 'Instant-Runoff Voting'.
 
-9.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
+2.1.3 Where there are at most as many nominees for a role as there are open positions, the Returning Officer can, without ballot, declare those candidates successful.
 
-## 10 Order of Elections
+## 2.2 Order of Elections
 
-10.1 At a General Meeting of The Association where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
+2.2.1 At a General Meeting of The Association where there are vacancies on the Executive Team, the order of the elections of the Executive Team shall be done by body in the following order:
 
 1. T3 Officers
 2. T5 Officers
 3. Executive Team
 
-10.2 Where a role resides in multiple bodies, they shall be elected as part of the first body to which they belong.
+2.2.2 Where a role resides in multiple bodies, they shall be elected as part of the first body to which they belong.
 
-10.3 The order of election of the T3 Officers shall be as follows:
+2.2.3 The order of election of the T3 Officers shall be as follows:
 
 1. President
 2. Secretary
 3. Treasurer
 
-10.4 The order of election of the T5 Officers shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+2.2.4 The order of election of the T5 Officers shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
 
 1. Vice President (Mechatronics)
 2. Vice President (Robotics)
 
-10.5 The order of election of the Executive Team shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
+2.2.5 The order of election of the Executive Team shall be in descending order of the number of eligible nominations for the role as of the closure of advance nominations, with any ties being determined by the following order:
 
 1. Marketing Lead
 2. Partnerships Lead
@@ -231,14 +232,14 @@ Within this document, the following definitions will be used:
 7. Outreach Lead
 8. Events Lead
 
-10.6 In this section, "advance nominations" refers to the nominations that can be submitted in advance of the general meeting and excludes those that would be presented from the floor.
+2.2.6 In this section, "advance nominations" refers to the nominations that can be submitted in advance of the general meeting and excludes those that would be presented from the floor.
 
-## 11 Election of the Returning Officer
+## 2.3 Election of the Returning Officer
 
-11.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
+2.3.1 Due to 9.1, a Returning Officer must be elected by the assembly to oversee all elections of the Executive Team, who can be neither a nominee for the Executive Team, nor a seconder of any nominee.
 
-11.2 The Returning Officer does not need to be a Association Member.
+2.3.2 The Returning Officer does not need to be a Association Member.
 
-11.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
+2.3.3 Provided that it is communicated at the time of election, the Returning Officer may be elected for a period of up to thirteen (13) calendar months to serve as the Returning Officer for all General Meetings that may occur within that time.
 
-11.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.
+2.3.4 Should a Returning Officer elected in advance as per 9.3 become ineligible to serve or not be present at a General Meeting, a new one shall be elected in their place.


### PR DESCRIPTION
Purely administrative, should not bare any impact on the meanings / impacts of the regs. Purely designed to remove coupling of the numbering between sections so that a change to the contents of one section does not produce complications with the numbering of any subsequent sections.

Simply, should make any future updates marginally simpler. Also makes it easier moving forward to abide by general good practice to refrain from updating the numbering of the document which bares influence on any external references.

In line with the constitution, shall be considered at the next Executive Team Meeting to occur on or after May 15, 2026.